### PR TITLE
Add method to get the shift applied by the homography for an input point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs
 dist
 .eggs
 *.egg-info
+venv/
+.DS_Store

--- a/test_homography.py
+++ b/test_homography.py
@@ -99,6 +99,12 @@ class TestHomography(unittest.TestCase):
         self.assertFalse(shift_by_eps.equal(identity, eps / 2.))
         self.assertAlmostEqual(shift_by_eps, identity)
 
+    def test_shift(self):
+        translation = np.array([2, 3])
+        h = Homography.translation(translation[0], translation[1])
+        shift = h.get_shift_at_point(np.array([0, 0]))
+        self.assertTrue(np.array_equal(shift, translation))
+
     @unittest.skipIf(no_cv2, 'Skipped since couldnt import opencv2.')
     def test_from_points(self):
         src = np.array(


### PR DESCRIPTION
Also encapsulates the functionality of adapting the input point (so it
can be either a Shapely point or a 1D 2 element numpy array).

Added test for the new method.

Rest of changes include code quality issues (autopep8 applied) and pt
renamed to point in the whole file to have coherency.